### PR TITLE
Fixed Numpy indexing error by casting to integers

### DIFF
--- a/plot_map.py
+++ b/plot_map.py
@@ -37,7 +37,7 @@ m = 0
 x_m = 0
 y_m = 0
 for i in range(0, len(z)):
-    data[round(x[i] * size), round(y[i] * size)] = z[i]
+    data[int(round(x[i] * size)), int(round(y[i] * size))] = z[i]
     if z[i] > m:
         x_m = round(x[i] * size)
         y_m = round(y[i] * size)


### PR DESCRIPTION
I got this error when running the script:

```
./sferes2/Candycane_2016-03-08_18_10_39_8508/archive_5.dat
Traceback (most recent call last):
  File "plot_map.py", line 40, in <module>
    data[round(x[i] * size), round(y[i] * size)] = z[i]
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

I think it's due to some changes in Numpy. The reason to why this is happening is because the value of round(x[i] \* size) is 1.0, not the integer 1, which can be seen in pdb:

```
../GaitAdaptation/sferes2/Candycane_2016-03-08_18_10_39_8508/archive_5.dat
> /home/gavekort/map_elites/plot_map.py(41)<module>()
-> data[int(round(x[i] * size)), int(round(y[i] * size))] = z[i]
(Pdb) p round(x[i] * size)
1.0
```

This was easily fixed by casting the value to an integer.
