### PR TITLE
Fixes for stat_map

### DIFF
--- a/stat_map.hpp
+++ b/stat_map.hpp
@@ -5,7 +5,7 @@
 #include <boost/multi_array.hpp>
 #include <sferes/stat/stat.hpp>
 
-#define MAP_WRITE_PARENTS
+// #define MAP_WRITE_PARENTS
 
 namespace sferes {
   namespace stat {
@@ -139,8 +139,11 @@ namespace sferes {
 
             ofs << offset << "    ";
             for(size_t dim = 0; dim < behav_dim; ++dim)
-              ofs << posinarray[dim] / (float) behav_shape[dim] << " ";
-            ofs << " " << array(posinarray)->fit().value() << std::endl;
+              ofs << posinarray[dim] / (float) ((behav_shape[dim] > 1) ? (behav_shape[dim]-1) : 1) << " ";
+            ofs << " " << array(posinarray)->fit().value() << " ";
+            for(size_t k = 0; k < array(posinarray)->gen().size(); ++k)
+              ofs << array(posinarray)->gen().data(k) << " ";
+            ofs << std::endl;
           }
           ++offset;
         }


### PR DESCRIPTION
3 changes in stat_map:
- We do not want by default to generate parent text archives
- Output also genotype in text archive
- Proper output of descriptor (division by behav_shape-1)
